### PR TITLE
Add npm build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "prepublish": "make clean build",
-    "test": "make test"
+    "test": "make test",
+    "build": "make build",
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I would have called it `start`, but I think `build` makes more sense because `make build`, builds the project in the `example` directory. Usually `npm start`, starts a web server that watches your files and auto reloads.