### PR TITLE
option to keep button in error state

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Put the button in the normal state.
 
 Put the button in the success state. Call the callback or the onSuccess prop when going back to the normal state.
 
-##### error([callback])
+##### error([callback, dontGoBackToNormal])
 
 Put the button in the error state. Call the callback or the onError prop when going back to the normal state.
 

--- a/README.md
+++ b/README.md
@@ -156,10 +156,12 @@ Put the button in the normal state.
 ##### success([callback, dontGoBackToNormal])
 
 Put the button in the success state. Call the callback or the onSuccess prop when going back to the normal state.
+Use `dontGoBackToNormal` flag to keep the button in success state (default is `false` so the button goes back to normal state after `durationSuccess`).
 
 ##### error([callback, dontGoBackToNormal])
 
 Put the button in the error state. Call the callback or the onError prop when going back to the normal state.
+Use `dontGoBackToNormal` flag to keep the button in error state (default is `false` so the button goes back to normal state after `durationError`).
 
 ## Styles
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ const App = React.createClass({
 
 All props are optional. All props other than that will be passed to the top element.
 
+##### controlled
+
+`true` if you control the button state (by providing `props.state` and `props.onClick`).`false` to let the button manage its state with Promises.  
+
 ##### classNamespace
 
 Namespace for CSS classes, default is `pb-` i.e CSS classes are `pb-button`.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Id of the form to submit (useful if the button is not directly inside the form).
 
 Whether click event should bubble when in loading state
 
+##### stayInSuccessState
+
+Keep the button in success state after setting state to "success" or calling `success()` method (regardless of `stayInSuccessState` argument value).
+default is `false`
+
+##### stayInErrorState
+
+Keep the button in error state after setting state to "error" or calling `error()` method (regardless of `stayInErrorState` argument value).
+default is `false`
+
 ### Methods
 
 ##### loading()
@@ -153,15 +163,16 @@ Put the button in the disabled state.
 
 Put the button in the normal state.
 
-##### success([callback, dontGoBackToNormal])
+##### success([callback, stayInSuccessState])
 
 Put the button in the success state. Call the callback or the onSuccess prop when going back to the normal state.
-Use `dontGoBackToNormal` flag to keep the button in success state (default is `false` so the button goes back to normal state after `durationSuccess`).
+Use `stayInSuccessState` flag to keep the button in success state (default is `false` so the button goes back to normal state after `durationSuccess`).
 
-##### error([callback, error, dontGoBackToNormal])
+##### error([callback, error, stayInErrorState])
 
 Put the button in the error state. Call the callback or the onError prop (with `error` argument) when going back to the normal state.
-Use `dontGoBackToNormal` flag to keep the button in error state (default is `false` so the button goes back to normal state after `durationError`).
+Use `stayInErrorState` flag to keep the button in error state (default is `false` so the button goes back to normal state after `durationError`).
+
 
 ## Styles
 

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Put the button in the normal state.
 Put the button in the success state. Call the callback or the onSuccess prop when going back to the normal state.
 Use `dontGoBackToNormal` flag to keep the button in success state (default is `false` so the button goes back to normal state after `durationSuccess`).
 
-##### error([callback, dontGoBackToNormal])
+##### error([callback, error, dontGoBackToNormal])
 
-Put the button in the error state. Call the callback or the onError prop when going back to the normal state.
+Put the button in the error state. Call the callback or the onError prop (with `error` argument) when going back to the normal state.
 Use `dontGoBackToNormal` flag to keep the button in error state (default is `false` so the button goes back to normal state after `durationError`).
 
 ## Styles

--- a/src/index.js
+++ b/src/index.js
@@ -168,10 +168,10 @@ const ProgressButton = createReactClass({
     }, this.props.durationSuccess)
   },
 
-  error (callback, err) {
+  error (callback, dontRemove, err) {
     this.setState({currentState: STATE.ERROR})
     this._timeout = setTimeout(() => {
-      this.setState({currentState: STATE.NOTHING})
+      if (!dontRemove) { this.setState({currentState: STATE.NOTHING}) }
       callback = callback || this.props.onError
       if (typeof callback === 'function') { callback(err) }
     }, this.props.durationError)

--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ const ProgressButton = createReactClass({
     this.setState({currentState: STATE.DISABLED})
   },
 
-  success (callback, dontRemove) {
+  success (callback, dontRemove = false) {
     this.setState({currentState: STATE.SUCCESS})
     this._timeout = setTimeout(() => {
       if (!dontRemove) { this.setState({currentState: STATE.NOTHING}) }
@@ -168,7 +168,7 @@ const ProgressButton = createReactClass({
     }, this.props.durationSuccess)
   },
 
-  error (callback, dontRemove, err) {
+  error (callback, err, dontRemove = false) {
     this.setState({currentState: STATE.ERROR})
     this._timeout = setTimeout(() => {
       if (!dontRemove) { this.setState({currentState: STATE.NOTHING}) }

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,9 @@ const ProgressButton = createReactClass({
     onSuccess: PropTypes.func,
     state: PropTypes.oneOf(Object.keys(STATE).map(k => STATE[k])),
     type: PropTypes.string,
-    shouldAllowClickOnLoading: PropTypes.bool
+    shouldAllowClickOnLoading: PropTypes.bool,
+    stayInSuccessState: PropTypes.bool,
+    stayInErrorState: PropTypes.bool
   },
 
   getDefaultProps () {
@@ -34,7 +36,9 @@ const ProgressButton = createReactClass({
       onClick () {},
       onError () {},
       onSuccess () {},
-      shouldAllowClickOnLoading: false
+      shouldAllowClickOnLoading: false,
+      stayInSuccessState: false,
+      stayInErrorState: false
     }
   },
 
@@ -86,6 +90,8 @@ const ProgressButton = createReactClass({
       state, // eslint-disable-line no-unused-vars
       shouldAllowClickOnLoading, // eslint-disable-line no-unused-vars
       controlled, // eslint-disable-line no-unused-vars
+      stayInSuccessState, // eslint-disable-line no-unused-vars
+      stayInErrorState, // eslint-disable-line no-unused-vars
       ...containerProps
     } = this.props
 
@@ -159,19 +165,19 @@ const ProgressButton = createReactClass({
     this.setState({currentState: STATE.DISABLED})
   },
 
-  success (callback, dontRemove = false) {
+  success (callback, stayInSuccessState = false) {
     this.setState({currentState: STATE.SUCCESS})
     this._timeout = setTimeout(() => {
-      if (!dontRemove) { this.setState({currentState: STATE.NOTHING}) }
+      if (!stayInSuccessState || !this.props.stayInSuccessState) { this.setState({currentState: STATE.NOTHING}) }
       callback = callback || this.props.onSuccess
       if (typeof callback === 'function') { callback() }
     }, this.props.durationSuccess)
   },
 
-  error (callback, err, dontRemove = false) {
+  error (callback, err, stayInErrorState = false) {
     this.setState({currentState: STATE.ERROR})
     this._timeout = setTimeout(() => {
-      if (!dontRemove) { this.setState({currentState: STATE.NOTHING}) }
+      if (!stayInErrorState || !this.props.stayInErrorState) { this.setState({currentState: STATE.NOTHING}) }
       callback = callback || this.props.onError
       if (typeof callback === 'function') { callback(err) }
     }, this.props.durationError)


### PR DESCRIPTION
This allows to force the button in error state (does no go back to NOTHING state after timeout `durationError`).

Can be useful in case the error is not recoverable (no need to re-click the button).