### PR TITLE
Add dontReenableAfterSuccess prop to support other default states bes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Id of the form to submit (useful if the button is not directly inside the form).
 
 Whether click event should bubble when in loading state
 
+##### dontReenableAfterSuccess
+
+After the button is put in the `'success'` state, it'll automatically go back to the enabled (`''`) state. Set this prop to `true` if the default state of your button should be something other than `''`. 
+
 ### Methods
 
 ##### loading()

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,8 @@ const ProgressButton = createReactClass({
     onSuccess: PropTypes.func,
     state: PropTypes.oneOf(Object.keys(STATE).map(k => STATE[k])),
     type: PropTypes.string,
-    shouldAllowClickOnLoading: PropTypes.bool
+    shouldAllowClickOnLoading: PropTypes.bool,
+    dontReenableAfterSuccess: PropTypes.bool
   },
 
   getDefaultProps () {
@@ -34,7 +35,8 @@ const ProgressButton = createReactClass({
       onClick () {},
       onError () {},
       onSuccess () {},
-      shouldAllowClickOnLoading: false
+      shouldAllowClickOnLoading: false,
+      dontReenableAfterSuccess: false
     }
   },
 
@@ -48,7 +50,7 @@ const ProgressButton = createReactClass({
     if (nextProps.state === this.props.state) { return }
     switch (nextProps.state) {
       case STATE.SUCCESS:
-        this.success()
+        this.success(null, this.props.dontReenableAfterSuccess)
         return
       case STATE.ERROR:
         this.error()


### PR DESCRIPTION
…ides enabled

There seems to be a bug where the `currentState` state value and the `state` prop fall out of sync. This manifested itself in my project when the default state of the button (what it should get set to after success according to the `onSuccess` prop) is something other than `''`.

The code already partially supports not automatically setting the button to enabled after success. This PR adds a prop which can be used to configure this. I tested this in my project and it works as expected when my code sets the button state to `'disabled'` after success.